### PR TITLE
add the novalidate attribute to the registration form

### DIFF
--- a/views/register.ejs
+++ b/views/register.ejs
@@ -21,7 +21,7 @@
             <% }) %>
         <% } %>
 
-        <form action="/register" method="POST">
+        <form action="/register" method="POST" novalidate>
             <div class="form-group">
                 <label for="username" class="form-label">Username</label>
                 <input type="text" class="form-control" name="username" id="username">


### PR DESCRIPTION
The built-in validation was blocking the  express-validator's alerts. The alerts were shown only if the e-mail field was empty or if it contained a valid e-mail address.